### PR TITLE
Updating since block operation causes 500 error

### DIFF
--- a/src/main/java/guru/springframework/spring5webfluxrest/controllers/CategoryController.java
+++ b/src/main/java/guru/springframework/spring5webfluxrest/controllers/CategoryController.java
@@ -42,17 +42,16 @@ public class CategoryController {
         return categoryRepository.save(category);
     }
 
-    @PatchMapping("/api/v1/categories/{id}")
-    Mono<Category> patch(@PathVariable String id, @RequestBody Category category) {
-
-        Category foundCategory = categoryRepository.findById(id).block();
-
-        if(foundCategory.getDescription() != category.getDescription()){
-            foundCategory.setDescription(category.getDescription());
-            return categoryRepository.save(foundCategory);
-        }
-
-        return Mono.just(foundCategory);
-    }
+	@PatchMapping(path = "/{id}")
+	public Mono<Category> patch(@PathVariable String id, @RequestBody Category category) {
+	return	categoryRepository.findById(id)
+				.flatMap(response -> {
+					if (response.getDescription() != category.getDescription()) {
+						response.setDescription(category.getDescription());
+						return categoryRepository.save(response);
+					}
+					return Mono.just(response);
+				});
+	}
 
 }


### PR DESCRIPTION
Original implementation fails in Postman because of the ".block()".   This version uses flatmap instead to do the update.